### PR TITLE
refactor(docker): optimize Dockerfile for better performance and smaller image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
-FROM python:3.12
+FROM python:3.12-alpine3.20
+
+EXPOSE 7777/tcp
+
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN pip3 install -r requirements.txt
+RUN pip install --no-cache-dir --disable-pip-version-check --no-compile -r requirements.txt
 
 COPY pywsgi.py ./
 COPY pluto.py ./
 
-RUN echo $PATH
-ENV PATH "/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin"
-RUN echo $PATH
-
-ENV PYTHONUNBUFFERED=1
-
-EXPOSE 7777/tcp
 CMD ["python3","pywsgi.py"]


### PR DESCRIPTION
## Changes

- Use Alpine Python image
- Use pip instead of pip3 (alias exists in image)
- Add `--no-cache-dir` flag to pip install
- Add `--disable-pip-version-check` flag to pip install
- Add `--no-compile` flag to pip install
- Remove redundant `$PATH` code
- Reorder commands for optimal layer caching

## Image Size

Reduced by ~92%

```
$ docker images | grep pluto
pluto-test                                latest            37930470ccbc   2 hours ago    145MB
ghcr.io/jgomez177/pluto-for-channels      latest            a2f8ceba8ea5   4 months ago   1.57GB
```
## Memory usage

Reduced by ~9%

```
CONTAINER ID   NAME                     CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O   PIDS
b1b8435515be   pluto-for-channels-old   0.02%     329MiB / 7.737GiB     4.15%     9.35MB / 605kB   0B / 0B     1
9c750c0de28e   pluto-for-channels       0.03%     305.2MiB / 7.737GiB   3.85%     9.32MB / 623kB   0B / 0B     1
```
